### PR TITLE
Add industry material stocks

### DIFF
--- a/definitions/variable/industry/material_stock.yaml
+++ b/definitions/variable/industry/material_stock.yaml
@@ -1,0 +1,27 @@
+# Material stocks by commodity
+- Material Stock|Iron and Steel|Steel:
+    description: Material stock of steel
+    unit: Mt
+- Material Stock|Non-Metallic Minerals|Cement:
+    description: Material stock of cement
+    unit: Mt
+- Material Stock|Non-Ferrous Metals|Aluminum:
+    description: Material stock of aluminum
+    unit: Mt
+- Material Stock|Non-Ferrous Metals|Copper:
+    description: Material stock of copper
+    unit: Mt
+
+# Material stocks by commodity and consumption sector
+- Material Stock|Iron and Steel|Steel|{Demand Sector}:
+    description: Material stock of steel in the {Demand Sector}
+    unit: Mt
+- Material Stock|Non-Metallic Minerals|Cement|{Demand Sector}:
+    description: Material stock of cement in the {Demand Sector}
+    unit: Mt
+- Material Stock|Non-Ferrous Metals|Aluminum|{Demand Sector}:
+    description: Material stock of aluminum in the {Demand Sector}
+    unit: Mt
+- Material Stock|Non-Ferrous Metals|Copper|{Demand Sector}:
+    description: Material stock of copper in the {Demand Sector}
+    unit: Mt


### PR DESCRIPTION
This PR adds `Material Stock|*` variables for materials and material-sector combinations required in PRISMA WP4.

It relies on some tags that are added in https://github.com/iiasa/prisma-workflow/pull/4 and needs to be rebased after #4 has been merged.