### PR TITLE
Add industry material scrap variables

### DIFF
--- a/definitions/variable/industry/scrap.yaml
+++ b/definitions/variable/industry/scrap.yaml
@@ -1,0 +1,25 @@
+- Total Scrap|Iron and Steel|Steel:
+    description: Total steel scrap
+    unit: Mt/yr
+- Total Scrap|Non-Metallic Minerals|Cement:
+    description: Total cement scrap
+    unit: Mt/yr
+- Total Scrap|Non-Ferrous Metals|Aluminum:
+    description: Total aluminum scrap
+    unit: Mt/yr
+- Total Scrap|Non-Ferrous Metals|Copper:
+    description: Total copper scrap
+    unit: Mt/yr
+
+- Total Scrap|Iron and Steel|Steel|{Demand Sector}:
+    description: Total steel scrap from {Demand Sector}
+    unit: Mt/yr
+- Total Scrap|Non-Metallic Minerals|Cement|{Demand Sector}:
+    description: Total cement scrap from {Demand Sector}
+    unit: Mt/yr
+- Total Scrap|Non-Ferrous Metals|Aluminum|{Demand Sector}:
+    description: Total aluminum scrap from {Demand Sector}
+    unit: Mt/yr
+- Total Scrap|Non-Ferrous Metals|Copper|{Demand Sector}:
+    description: Total copper scrap from {Demand Sector}
+    unit: Mt/yr

--- a/definitions/variable/industry/scrap.yaml
+++ b/definitions/variable/industry/scrap.yaml
@@ -1,25 +1,33 @@
-- Total Scrap|Iron and Steel|Steel:
-    description: Total steel scrap
+- Scrap|Iron and Steel|Steel:
+    description: Total potential of steel scrap material as a result of end of
+      life products (before collection)
     unit: Mt/yr
-- Total Scrap|Non-Metallic Minerals|Cement:
-    description: Total cement scrap
+- Scrap|Non-Metallic Minerals|Cement:
+    description: Total potential of cement scrap material as a result of end of
+      life products (before collection)
     unit: Mt/yr
-- Total Scrap|Non-Ferrous Metals|Aluminum:
-    description: Total aluminum scrap
+- Scrap|Non-Ferrous Metals|Aluminum:
+    description: Total potential of aluminum scrap material as a result of end of
+      life products (before collection)
     unit: Mt/yr
-- Total Scrap|Non-Ferrous Metals|Copper:
-    description: Total copper scrap
+- Scrap|Non-Ferrous Metals|Copper:
+    description: Total potential of copper scrap material as a result of end of
+      life products (before collection)
     unit: Mt/yr
 
-- Total Scrap|Iron and Steel|Steel|{Demand Sector}:
-    description: Total steel scrap from {Demand Sector}
+- Scrap|Iron and Steel|Steel|{Demand Sector}:
+    description: Total potential of steel scrap material as a result of
+      end of life products (before collection) from {Demand Sector}
     unit: Mt/yr
-- Total Scrap|Non-Metallic Minerals|Cement|{Demand Sector}:
-    description: Total cement scrap from {Demand Sector}
+- Scrap|Non-Metallic Minerals|Cement|{Demand Sector}:
+    description: Total potential of cement scrap material as a result of
+      end of life products (before collection) from {Demand Sector}
     unit: Mt/yr
-- Total Scrap|Non-Ferrous Metals|Aluminum|{Demand Sector}:
-    description: Total aluminum scrap from {Demand Sector}
+- Scrap|Non-Ferrous Metals|Aluminum|{Demand Sector}:
+    description: Total potential of aluminum scrap material as a result of
+      end of life products (before collection) from {Demand Sector}
     unit: Mt/yr
-- Total Scrap|Non-Ferrous Metals|Copper|{Demand Sector}:
-    description: Total copper scrap from {Demand Sector}
+- Scrap|Non-Ferrous Metals|Copper|{Demand Sector}:
+    description: Total potential of copper scrap material as a result of
+      end of life products (before collection) from {Demand Sector}
     unit: Mt/yr


### PR DESCRIPTION
This PR adds `Total Scrap|*` variables for materials and material-sector combinations required in PRISMA WP4.

It relies on some tags that are added in https://github.com/iiasa/prisma-workflow/pull/4 and needs to be rebased after #4 has been merged.