### PR TITLE
Add custom final energy variable module and required tags

### DIFF
--- a/definitions/variable/energy/final-energy-copper.yaml
+++ b/definitions/variable/energy/final-energy-copper.yaml
@@ -1,0 +1,17 @@
+# Final energy by sector and fuel
+- Final Energy|{Sector}:
+    description: Final energy consumption by the {Sector}
+    unit: EJ/yr
+    tier: 1
+- Final Energy|{Sector}|Electricity:
+    description: Final energy consumption by the {Sector} of electricity
+    unit: EJ/yr
+    tier: 1
+- Final Energy|{Sector}|{Secondary Fuel Level 2}:
+    description: Final energy consumption by the {Sector} of {Secondary Fuel Level 2}
+    unit: EJ/yr
+    tier: 1
+- Final Energy|{Sector}|Other:
+    description: Final energy consumption by the {Sector} of other energy sources
+    unit: EJ/yr
+    tier: 2

--- a/definitions/variable/energy/tag_all_sectors.yaml
+++ b/definitions/variable/energy/tag_all_sectors.yaml
@@ -1,0 +1,4 @@
+- Sector:
+    - Industry|Non-Ferrous Metals|Copper:
+        description: copper sector
+        tier: ^1

--- a/definitions/variable/energy/tag_secondary_energy_carriers_level-2.yaml
+++ b/definitions/variable/energy/tag_secondary_energy_carriers_level-2.yaml
@@ -1,0 +1,141 @@
+- Secondary Fuel Level 2:
+    # This list has secondary-energy carriers together with their origin
+    # (e.g., liquids from hydrogen)
+    # Electricity is treated separately from other secondary energy carriers
+    # This should be a super-set of `tag_secondary_energy_carriers_level-1.yaml`
+    - Liquids:
+        description: refined liquid fuels including oil products, fuels from gas and coal,
+          synthetic fuels and biofuels
+    - Liquids|Biomass:
+        description: liquid fuels from biomass
+        tier: ^1
+    - Liquids|Fossil:
+        description: liquid fuels from fossil fuels including coal, natural gas and
+          conventional/unconventional oil
+        tier: ^1
+    - Liquids|Oil:
+        description: liquid fuels from refined crude oil
+        tier: ^1
+    - Liquids|Coal:
+        description: liquid fuels from coal
+        tier: ^1
+    - Liquids|Gas:
+        description: liquid fuels from fossil methane ('natural gas')
+        tier: ^1
+    - Liquids|Hydrogen:
+        description: liquid fuels from hydrogen (if hydrogen is explicitly modeled as a
+          commodity and not an implicit intermediate product of the transformation technologies)
+        tier: ^1
+    - Liquids|Electricity:
+        description: liquid synthetic fuels from electricity, i.e., e-fuels (if hydrogen
+          is not explicitly modeled as an intermediate product)
+        tier: ^1
+    - Liquids|Other:
+        description: sources that do not fit any other category
+        tier: ^1
+
+    - Solids:
+        description: solid energy carriers, including coal, briquettes, coke,
+          and wood pellets
+    - Solids|Biomass:
+        description: solid biomass (e.g., commercial charcoal, wood chips, wood pellets),
+          not including traditional bioenergy
+        tier: ^1
+    - Solids|Coal:
+        description: coal, lignite, and derived products (e.g., coke, briquettes)
+        tier: ^1
+
+    - Gases:
+        description: gaseous fuels including natural gas and biogas, not including hydrogen
+    - Gases|Biomass:
+        description: gaseous fuels from biogenic sources, mainly biogas
+        tier: ^1
+    - Gases|Fossil:
+        description: gaseous fuels from fossil fuels including natural gas and coal
+        tier: ^1
+    - Gases|Coal:
+        description: gaseous fuels from fossil coal gasification
+        tier: ^1
+    - Gases|Gas:
+        description: fossil methane ('natural gas')
+        tier: ^1
+    - Gases|Hydrogen:
+        description: gaseous fuels from hydrogen (if hydrogen is explicitly modeled as a
+          commodity and not an implicit intermediate product of the transformation technologies)
+        tier: ^1
+    - Gases|Electricity:
+        description: gas from electricity i.e., 'power-to-gas' (if hydrogen is not
+          explicitly modeled as an intermediate product)
+        tier: ^1
+    - Gases|Other:
+        description: gaseous fuels from sources that do not fit any other category
+        tier: ^1
+
+    - Hydrogen:
+        description: hydrogen
+    - Hydrogen|Biomass:
+        description: hydrogen generated from biomass
+        tier: ^1
+    - Hydrogen|Fossil:
+        description: hydrogen from fossil fuels including natural gas, oil and coal
+        tier: ^1
+    - Hydrogen|Oil:
+        description: hydrogen from refined crude oil
+        tier: ^1
+    - Hydrogen|Coal:
+        description: hydrogen from coal
+        tier: ^1
+    - Hydrogen|Gas:
+        description: hydrogen from fossil methane ('natural gas')
+        tier: ^1
+    - Hydrogen|Electricity:
+        description: hydrogen from electrolysis
+        tier: ^1
+    - Hydrogen|Nuclear:
+        description: hydrogen from nuclear energy
+          (e.g. thermochemical water splitting with nuclear heat)
+        tier: ^1
+    - Hydrogen|Solar:
+        description: hydrogen from solar energy
+          (e.g. thermochemical water splitting with solar heat)
+        tier: ^1
+    - Hydrogen|Other:
+        description: hydrogen from other sources
+        tier: ^1
+
+    - Heat:
+        description: centralized heat
+    - Heat|Biomass:
+        description: centralized heat from biomass, including biogas
+        tier: ^1
+    - Heat|Fossil:
+        description: centralized heat from fossil fuels including natural gas, oil and coal
+        tier: ^1
+    - Heat|Oil:
+        description: centralized heat from refined crude oil
+        tier: ^1
+    - Heat|Coal:
+        description: centralized heat from coal
+        tier: ^1
+    - Heat|Gas:
+        description: centralized heat from fossil methane ('natural gas')
+        tier: ^1
+    - Heat|Hydrogen:
+        description: centralized heat from hydrogen
+        tier: ^1
+    - Heat|Geothermal:
+        description: centralized heat from geothermal energy excluding ground-source heat pumps
+        tier: ^1
+    - Heat|Electricity:
+        description: centralized heat from electricity
+        tier: ^1
+    - Heat|Nuclear:
+        description: centralized heat from nuclear energy
+        tier: ^1
+    - Heat|Solar:
+        description: centralized heat from solar energy
+        tier: ^1
+    - Heat|Other:
+        description: centralized heat from sources that do not fit any other category
+        tier: ^1
+


### PR DESCRIPTION
This PR adds `Final Energy|Industry|Non-Ferrous Metals|Copper*` variables.

The required `Secondary Fuel Level 2` tags needed were copied from `common-definitions`.