### PR TITLE
Set up common-definitions filters

### DIFF
--- a/nomenclature.yaml
+++ b/nomenclature.yaml
@@ -22,7 +22,8 @@ definitions:
           tier: [ 1, 2 ]
         - name: [ Emissions|Kyoto Gases*, Emissions|F-Gases* ]
           tier: 1
-        - name: [ Emissions|CO2|*|Industr*, Emissions|CH4|*|Industr*, Emissions|N2O|*|Industr* ]
+        - name: [ Emissions|CO2|Industrial Processes*, Emissions|CH4|Industrial Processes*, Emissions|N2O|Industrial Processes* ]
+        - name: [ Emissions|CO2|Energy|Demand|Industry*, Emissions|CH4|Energy|Demand|Industry*, Emissions|N2O|Energy|Demand|Industry* ]
 
 mappings:
   repository: common-definitions

--- a/nomenclature.yaml
+++ b/nomenclature.yaml
@@ -8,20 +8,21 @@ definitions:
   region:
     repository: common-definitions
   variable:
-    repository: common-definitions
-    include:
-      - name: "Primary Energy*"
-        depth: [ 1, 2 ]
-      - name: "Secondary Energy*"
-        tier: [ 1, 2 ]
-      - name: "Final Energy*"
-        tier: 1
-      - name: [ Final Energy|Non-Energy Use*, Final Energy|Industry* ]
-      - name: [ Emissions|CH4*, Emissions|CO2*, Emissions|N2O* ]
-        tier: [ 1, 2 ]
-      - name: [ Emissions|Kyoto*, Emissions|F-Gases* ]
-        tier: 1
-      - name: [ Emissions|CO2|*|Industr*, Emissions|CH4|*|Industr*, Emissions|N2O|*|Industr* ]
+    repository:
+      name: common-definitions
+      include:
+        - name: Primary Energy*
+          depth: [ 1, 2 ]
+        - name: Secondary Energy*
+          tier: [ 1, 2 ]
+        - name: Final Energy*
+          tier: 1
+        - name: [ Final Energy|Non-Energy Use*, Final Energy|Industry* ]
+        - name: [ Emissions|CH4*, Emissions|CO2*, Emissions|N2O* ]
+          tier: [ 1, 2 ]
+        - name: [ Emissions|Kyoto Gases*, Emissions|F-Gases* ]
+          tier: 1
+        - name: [ Emissions|CO2|*|Industr*, Emissions|CH4|*|Industr*, Emissions|N2O|*|Industr* ]
 
 mappings:
   repository: common-definitions

--- a/nomenclature.yaml
+++ b/nomenclature.yaml
@@ -9,5 +9,19 @@ definitions:
     repository: common-definitions
   variable:
     repository: common-definitions
+    include:
+      - name: "Primary Energy*"
+        depth: [ 1, 2 ]
+      - name: "Secondary Energy*"
+        tier: [ 1, 2 ]
+      - name: "Final Energy*"
+        tier: 1
+      - name: [ Final Energy|Non-Energy Use*, Final Energy|Industry* ]
+      - name: [ Emissions|CH4*, Emissions|CO2*, Emissions|N2O* ]
+        tier: [ 1, 2 ]
+      - name: [ Emissions|Kyoto*, Emissions|F-Gases* ]
+        tier: 1
+      - name: [ Emissions|CO2|*|Industr*, Emissions|CH4|*|Industr*, Emissions|N2O|*|Industr* ]
+
 mappings:
   repository: common-definitions


### PR DESCRIPTION
Include only variables from common-defintions that were selected for WP4 intercomparison exercise.