### PR TITLE
Extend PRISMA WP4 template

### DIFF
--- a/definitions/variable/industry/material_demand.yaml
+++ b/definitions/variable/industry/material_demand.yaml
@@ -41,3 +41,25 @@
     description: Demand of {Chemicals Commodity} in {Demand Sector}
     unit: Mt/yr
     tier: 2
+
+# material demand by commodity and manufactured goods category
+- Material Demand|Iron and Steel|Steel|{Material Use}:
+    description: Demand of steel commodities in {Material Use}
+    unit: Mt/yr
+    tier: 2
+- Material Demand|Non-Metallic Minerals|Cement|{Material Use}:
+    description: Demand of cement in {Material Use}
+    unit: Mt/yr
+    tier: 2
+- Material Demand|Non-Ferrous Metals|Aluminum|{Material Use}:
+    description: Demand of aluminum in {Material Use}
+    unit: Mt/yr
+    tier: 2
+- Material Demand|Non-Ferrous Metals|Copper|{Material Use}:
+    description: Demand of copper in {Material Use}
+    unit: Mt/yr
+    tier: 2
+- Material Demand|Chemicals|{Chemicals Commodity}|{Material Use}:
+    description: Demand of {Chemicals Commodity} in {Material Use}
+    unit: Mt/yr
+    tier: 2

--- a/definitions/variable/industry/tag_demand_sectors.yaml
+++ b/definitions/variable/industry/tag_demand_sectors.yaml
@@ -17,11 +17,13 @@
           description: construction of wind turbines
     - Electricity|Transmission and Distribution:
           description: electricity transmission and distribution
+    - Transportation|Infrastructure:
+        description: fixed structures, installations and networks for mobility (e.g roads, bridges, rail, waterways) excluding means of transportation (e.g. cars, trains, airplanes)
     - Transportation|Vehicle Stock:
         description: vehicle stock (e.g. cars, trains, airplanes, ships)
     - Residential:
         description: residential sector
     - Commercial:
         description: commercial sector
-    - Transportation|Infrastructure:
-        description: fixed structures, installations and networks for mobility (e.g roads, bridges, rail, waterways) excluding means of transportation (e.g. cars, trains, airplanes)
+    - Residential and Commercial:
+        description: residential and commercial sector

--- a/definitions/variable/industry/tag_material_use.yaml
+++ b/definitions/variable/industry/tag_material_use.yaml
@@ -1,0 +1,19 @@
+- Material Use:
+    - Vehicles:
+        description: vehicle stock (e.g. cars, trains, airplanes, ships)
+    - Construction|Buildings|Residential:
+        description: residential buildings
+    - Construction|Buildings|Commercial:
+        description: commercial buildings
+    - Construction|Civil Engineering:
+        description: civil engineering structures for transportation, utilities, and other infrastructure
+    - Machinery:
+        description: machinery and equipment mostly used in industries
+    - Appliances:
+        description: appliances mostly used commercially and in households
+    - Consumer Goods:
+        description: consumer goods such as clothing, furniture, and electronics
+    - Packaging:
+        description: packaging materials
+    - Other:
+        description: other manufactured goods not specified above


### PR DESCRIPTION
This PR adds some extra sub-variables that are required for the materials model inter comparison in the work package 4 (WP4) of the PRISMA project.

The extension is a result of recent discussions with @JakobBD, that aims to make post-processing of the REMIND-MFA results easier.

The PR is WIP and should be used to discuss the final implementation before merging.