### PR TITLE
Add scenario naming for PRISMA ICT sector scenarios under WP4

### DIFF
--- a/definitions/scenario/scenarios.yaml
+++ b/definitions/scenario/scenarios.yaml
@@ -1,0 +1,2 @@
+- "{SSP} - {Climate Policy} - {ICT Demand}":
+    description: "{SSP} combined with '{Climate Policy}' climate policy assumptions and '{ICT Demand}' ICT sector demand development"

--- a/definitions/scenario/scenarios.yaml
+++ b/definitions/scenario/scenarios.yaml
@@ -1,2 +1,4 @@
 - "{SSP} - {Climate Policy} - {ICT Demand}":
     description: "{SSP} combined with '{Climate Policy}' climate policy assumptions and '{ICT Demand}'"
+- "{SSP} - {ScenarioMIP}":
+    description: "{SSP} combined with '{ScenarioMIP}' climate policy assumptions following the ScenarioMIP protocol"

--- a/definitions/scenario/scenarios.yaml
+++ b/definitions/scenario/scenarios.yaml
@@ -1,2 +1,2 @@
 - "{SSP} - {Climate Policy} - {ICT Demand}":
-    description: "{SSP} combined with '{Climate Policy}' climate policy assumptions and '{ICT Demand}' ICT sector demand development"
+    description: "{SSP} combined with '{Climate Policy}' climate policy assumptions and '{ICT Demand}'"

--- a/definitions/scenario/tag_climate_policy.yaml
+++ b/definitions/scenario/tag_climate_policy.yaml
@@ -1,0 +1,5 @@
+- Climate Policy:
+    - Current Policies
+        description: "current climate policies including extrapolation of ambition into the future"
+    - Net-Zero
+        description: "implementation of unconditional NDCs until 2030 and net-zero targets"

--- a/definitions/scenario/tag_climate_policy.yaml
+++ b/definitions/scenario/tag_climate_policy.yaml
@@ -1,5 +1,5 @@
 - Climate Policy:
     - Current Policies:
-        description: "current climate policies including extrapolation of ambition into the future"
+        description: current climate policies including extrapolation of ambition into the future
     - Net-Zero:
-        description: "implementation of unconditional NDCs until 2030 and net-zero targets"
+        description: implementation of unconditional NDCs until 2030 and net-zero targets

--- a/definitions/scenario/tag_climate_policy.yaml
+++ b/definitions/scenario/tag_climate_policy.yaml
@@ -1,5 +1,5 @@
 - Climate Policy:
-    - Current Policies
+    - Current Policies:
         description: "current climate policies including extrapolation of ambition into the future"
-    - Net-Zero
+    - Net-Zero:
         description: "implementation of unconditional NDCs until 2030 and net-zero targets"

--- a/definitions/scenario/tag_ict_demand.yaml
+++ b/definitions/scenario/tag_ict_demand.yaml
@@ -1,7 +1,7 @@
 - ICT Demand:
     - High ICT:
-        description: "high ICT sector demand development"
+        description: high ICT sector demand development
     - Medium ICT:
-        description: "medium ICT sector demand development"
+        description: medium ICT sector demand development
     - Low ICT:
-        description: "low ICT sector demand development"
+        description: low ICT sector demand development

--- a/definitions/scenario/tag_ict_demand.yaml
+++ b/definitions/scenario/tag_ict_demand.yaml
@@ -1,7 +1,7 @@
 - ICT Demand:
-    - High ICT
+    - High ICT:
         description: "high ICT sector demand development"
-    - Medium ICT
+    - Medium ICT:
         description: "medium ICT sector demand development"
-    - Low ICT
+    - Low ICT:
         description: "low ICT sector demand development"

--- a/definitions/scenario/tag_ict_demand.yaml
+++ b/definitions/scenario/tag_ict_demand.yaml
@@ -1,0 +1,7 @@
+- ICT Demand:
+    - High ICT
+        description: "high ICT sector demand development"
+    - Medium ICT
+        description: "medium ICT sector demand development"
+    - Low ICT
+        description: "low ICT sector demand development"

--- a/definitions/scenario/tag_scenario_mip.yaml
+++ b/definitions/scenario/tag_scenario_mip.yaml
@@ -1,0 +1,8 @@
+- ScenarioMIP:
+    - High Emissions
+    - Medium Emissions
+    - Medium-Low Emissions
+    - Low Emissions
+    - Very Low Emissions
+    - Medium Overshoot
+    - Low Overshoot

--- a/definitions/scenario/tag_ssp.yaml
+++ b/definitions/scenario/tag_ssp.yaml
@@ -1,0 +1,11 @@
+- SSP:
+    - SSP1:
+        description: "'Sustainability – Taking the Green Road' (SSP1)"
+    - SSP2:
+        description: "'Middle of the Road' (SSP2)"
+    - SSP3:
+        description: "'Regional Rivalry – A Rocky Road' (SSP3)"
+    - SSP4:
+        description: "'Inequality – A Road Divided' (SSP4)"
+    - SSP5:
+        description: "'Fossil-fueled Development – Taking the Highway' (SSP5)"


### PR DESCRIPTION
Add scenario naming composed of three elements:
- SSP (taken from ssp-submission-workflow)
- climate policy 
- ict sector demand