### PR TITLE
Remove common-definitions variable filters

### DIFF
--- a/nomenclature.yaml
+++ b/nomenclature.yaml
@@ -9,21 +9,6 @@ definitions:
   variable:
     repository:
       name: common-definitions
-      include:
-        - name: Primary Energy*
-          depth: [ 1, 2 ]
-        - name: Secondary Energy*
-          tier: [ 1, 2 ]
-        - name: Final Energy*
-          tier: 1
-        - name: [ Final Energy|Non-Energy Use*, Final Energy|Industry* ]
-        - name: [ Emissions|CH4*, Emissions|CO2*, Emissions|N2O* ]
-          tier: [ 1, 2 ]
-        - name: [ Emissions|Kyoto Gases*, Emissions|F-Gases* ]
-          tier: 1
-        - name: [ Emissions|CO2|Industrial Processes*, Emissions|CH4|Industrial Processes*, Emissions|N2O|Industrial Processes* ]
-        - name: [ Emissions|CO2|Energy|Demand|Industry*, Emissions|CH4|Energy|Demand|Industry*, Emissions|N2O|Energy|Demand|Industry* ]
-        - name: [ Production|* ]
   region:
     repository:
       name: common-definitions


### PR DESCRIPTION
This PR removes the previously used filters on the variable import from common-definitions.
This commit undoes the changes from #8.

This update is needed for both WP4 ICT scenario submissions and WP6 scenario submissions as they require a full variable set from common-definitions.