### PR TITLE
Add mapping for IFs v8.54

### DIFF
--- a/mappings/IFs_v8.54.yaml
+++ b/mappings/IFs_v8.54.yaml
@@ -35,7 +35,7 @@ native_regions:
   - CHN: China
   - CIV: Côte d'Ivoire
   - CMR: Cameroon
-  - COG: Democratic Republic of the Congo
+  - COG: Congo
   - COL: Colombia
   - COM: Comoros
   - CPV: Cabo Verde
@@ -93,7 +93,7 @@ native_regions:
   - KHM: Cambodia
   - KIR: Kiribati
   - KOR: South Korea
-  - KSV: Kosovo
+  - KOS: Kosovo
   - KWT: Kuwait
   - LAO: Laos 
   - LBN: Lebanon
@@ -139,8 +139,9 @@ native_regions:
   - PRK: North Korea
   - PRT: Portugal
   - PRY: Paraguay
+  - PSE: Palestine
   - QAT: Qatar
-  - ROM: Romania
+  - ROU: Romania
   - RUS: Russian Federation
   - RWA: Rwanda
   - SAU: Saudi Arabia
@@ -166,7 +167,7 @@ native_regions:
   - THA: Thailand
   - TJK: Tajikistan
   - TKM: Turkmenistan
-  - TMP: Timor-Leste
+  - TLS: Timor-Leste
   - TON: Tonga
   - TTO: Trinidad and Tobago
   - TUN: Tunisia
@@ -182,7 +183,6 @@ native_regions:
   - VEN: Venezuela
   - VNM: Viet Nam
   - VUT: Vanuatu
-  - WBG: Palestine
   - WSM: Samoa
   - YEM: Yemen
   - ZAF: South Africa

--- a/mappings/IFs_v8.54.yaml
+++ b/mappings/IFs_v8.54.yaml
@@ -1,0 +1,872 @@
+model:
+  - IFs 8.54
+
+native_regions:
+  - AFG: Afghanistan
+  - AGO: Angola
+  - ALB: Albania
+  - ARE: United Arab Emirates
+  - ARG: Argentina
+  - ARM: Armenia
+  - AUS: Australia
+  - AUT: Austria
+  - AZE: Azerbaijan
+  - BDI: Burundi
+  - BEL: Belgium
+  - BEN: Benin
+  - BFA: Burkina Faso
+  - BGD: Bangladesh
+  - BGR: Bulgaria
+  - BHR: Bahrain
+  - BHS: Bahamas 
+  - BIH: Bosnia and Herzegovina
+  - BLR: Belarus
+  - BLZ: Belize
+  - BOL: Bolivia
+  - BRA: Brazil
+  - BRB: Barbados
+  - BRN: Brunei Darussalam
+  - BTN: Bhutan
+  - BWA: Botswana
+  - CAF: Central African Republic 
+  - CAN: Canada
+  - CHE: Switzerland
+  - CHL: Chile
+  - CHN: China
+  - CIV: Côte d'Ivoire
+  - CMR: Cameroon
+  - COG: Democratic Republic of the Congo
+  - COL: Colombia
+  - COM: Comoros
+  - CPV: Cabo Verde
+  - CRI: Costa Rica
+  - CUB: Cuba
+  - CYP: Cyprus
+  - CZE: Czechia
+  - DEU: Germany
+  - DJI: Djibouti
+  - DNK: Denmark
+  - DOM: Dominican Republic 
+  - DZA: Algeria
+  - ECU: Ecuador
+  - EGY: Egypt
+  - ERI: Eritrea
+  - ESH: Western Sahara
+  - ESP: Spain
+  - EST: Estonia
+  - ETH: Ethiopia
+  - FIN: Finland
+  - FJI: Fiji
+  - FRA: France
+  - FSM: Micronesia
+  - GAB: Gabon
+  - GBR: United Kingdom
+  - GEO: Georgia
+  - GHA: Ghana
+  - GIN: Guinea
+  - GMB: Gambia 
+  - GNB: Guinea-Bissau
+  - GNQ: Equatorial Guinea
+  - GRC: Greece
+  - GRD: Grenada
+  - GTM: Guatemala
+  - GUY: Guyana
+  - HKG: Hong Kong
+  - HND: Honduras
+  - HRV: Croatia
+  - HTI: Haiti
+  - HUN: Hungary
+  - IDN: Indonesia
+  - IND: India
+  - IRL: Ireland
+  - IRN: Iran
+  - IRQ: Iraq
+  - ISL: Iceland
+  - ISR: Israel
+  - ITA: Italy
+  - JAM: Jamaica
+  - JOR: Jordan
+  - JPN: Japan
+  - KAZ: Kazakhstan
+  - KEN: Kenya
+  - KGZ: Kyrgyzstan
+  - KHM: Cambodia
+  - KIR: Kiribati
+  - KOR: South Korea
+  - KSV: Kosovo
+  - KWT: Kuwait
+  - LAO: Laos 
+  - LBN: Lebanon
+  - LBR: Liberia
+  - LBY: Libya
+  - LCA: Saint Lucia
+  - LKA: Sri Lanka
+  - LSO: Lesotho
+  - LTU: Lithuania
+  - LUX: Luxembourg
+  - LVA: Latvia
+  - MAR: Morocco
+  - MDA: Moldova
+  - MDG: Madagascar
+  - MDV: Maldives
+  - MEX: Mexico
+  - MKD: North Macedonia
+  - MLI: Mali
+  - MLT: Malta
+  - MMR: Myanmar
+  - MNG: Mongolia
+  - MOZ: Mozambique
+  - MRT: Mauritania
+  - MUS: Mauritius
+  - MWI: Malawi
+  - MYS: Malaysia
+  - NAM: Namibia
+  - NER: Niger 
+  - NGA: Nigeria
+  - NIC: Nicaragua
+  - NLD: Netherlands 
+  - NOR: Norway
+  - NPL: Nepal
+  - NZL: New Zealand
+  - OMN: Oman
+  - PAK: Pakistan
+  - PAN: Panama
+  - PER: Peru
+  - PHL: Philippines 
+  - PNG: Papua New Guinea
+  - POL: Poland
+  - PRI: Puerto Rico
+  - PRK: North Korea
+  - PRT: Portugal
+  - PRY: Paraguay
+  - QAT: Qatar
+  - ROM: Romania
+  - RUS: Russian Federation
+  - RWA: Rwanda
+  - SAU: Saudi Arabia
+  - SDN: Sudan 
+  - SEN: Senegal
+  - SGP: Singapore
+  - SLB: Solomon Islands
+  - SLE: Sierra Leone
+  - SLV: El Salvador
+  - SOM: Somalia
+  - SRB: Serbia
+  - SSD: South Sudan
+  - STP: Sao Tome and Principe
+  - SUR: Suriname
+  - SVK: Slovakia
+  - SVN: Slovenia
+  - SWE: Sweden
+  - SWZ: Eswatini
+  - SYC: Seychelles
+  - SYR: Syria
+  - TCD: Chad
+  - TGO: Togo
+  - THA: Thailand
+  - TJK: Tajikistan
+  - TKM: Turkmenistan
+  - TMP: Timor-Leste
+  - TON: Tonga
+  - TTO: Trinidad and Tobago
+  - TUN: Tunisia
+  - TUR: Turkey
+  - TWN: Taiwan
+  - TZA: Tanzania
+  - UGA: Uganda
+  - UKR: Ukraine
+  - URY: Uruguay
+  - USA: United States
+  - UZB: Uzbekistan
+  - VCT: Saint Vincent and the Grenadines
+  - VEN: Venezuela
+  - VNM: Viet Nam
+  - VUT: Vanuatu
+  - WBG: Palestine
+  - WSM: Samoa
+  - YEM: Yemen
+  - ZAF: South Africa
+  - ZMB: Zambia
+  - ZWE: Zimbabwe
+
+common_regions:
+  - World:
+    - AFG
+    - AGO
+    - ALB
+    - ARE
+    - ARG
+    - ARM
+    - AUS
+    - AUT
+    - AZE
+    - BDI
+    - BEL
+    - BEN
+    - BFA
+    - BGD
+    - BGR
+    - BHR
+    - BHS
+    - BIH
+    - BLR
+    - BLZ
+    - BOL
+    - BRA
+    - BRB
+    - BRN
+    - BTN
+    - BWA
+    - CAF
+    - CAN
+    - CHE
+    - CHL
+    - CHN
+    - CIV
+    - CMR
+    - COG
+    - COL
+    - COM
+    - CPV
+    - CRI
+    - CUB
+    - CYP
+    - CZE
+    - DEU
+    - DJI
+    - DNK
+    - DOM
+    - DZA
+    - ECU
+    - EGY
+    - ERI
+    - ESH
+    - ESP
+    - EST
+    - ETH
+    - FIN
+    - FJI
+    - FRA
+    - FSM
+    - GAB
+    - GBR
+    - GEO
+    - GHA
+    - GIN
+    - GMB
+    - GNB
+    - GNQ
+    - GRC
+    - GRD
+    - GTM
+    - GUY
+    - HKG
+    - HND
+    - HRV
+    - HTI
+    - HUN
+    - IDN
+    - IND
+    - IRL
+    - IRN
+    - IRQ
+    - ISL
+    - ISR
+    - ITA
+    - JAM
+    - JOR
+    - JPN
+    - KAZ
+    - KEN
+    - KGZ
+    - KHM
+    - KIR
+    - KOR
+    - KSV
+    - KWT
+    - LAO
+    - LBN
+    - LBR
+    - LBY
+    - LCA
+    - LKA
+    - LSO
+    - LTU
+    - LUX
+    - LVA
+    - MAR
+    - MDA
+    - MDG
+    - MDV
+    - MEX
+    - MKD
+    - MLI
+    - MLT
+    - MMR
+    - MNG
+    - MOZ
+    - MRT
+    - MUS
+    - MWI
+    - MYS
+    - NAM
+    - NER
+    - NGA
+    - NIC
+    - NLD
+    - NOR
+    - NPL
+    - NZL
+    - OMN
+    - PAK
+    - PAN
+    - PER
+    - PHL
+    - PNG
+    - POL
+    - PRI
+    - PRK
+    - PRT
+    - PRY
+    - QAT
+    - ROM
+    - RUS
+    - RWA
+    - SAU
+    - SDN
+    - SEN
+    - SGP
+    - SLB
+    - SLE
+    - SLV
+    - SOM
+    - SRB
+    - SSD
+    - STP
+    - SUR
+    - SVK
+    - SVN
+    - SWE
+    - SWZ
+    - SYC
+    - SYR
+    - TCD
+    - TGO
+    - THA
+    - TJK
+    - TKM
+    - TMP
+    - TON
+    - TTO
+    - TUN
+    - TUR
+    - TWN
+    - TZA
+    - UGA
+    - UKR
+    - URY
+    - USA
+    - UZB
+    - VCT
+    - VEN
+    - VNM
+    - VUT
+    - WBG
+    - WSM
+    - YEM
+    - ZAF
+    - ZMB
+    - ZWE
+  
+  # R5 regions
+  - OECD & EU (R5):
+    - AUT
+    - BEL
+    - CAN
+    - CHE
+    - CHL
+    - COL
+    - CRI
+    - DEU
+    - DNK
+    - ESP
+    - EST
+    - FIN
+    - FRA
+    - GBR
+    - GRC
+    - HUN
+    - IRL
+    - ISL
+    - ISR
+    - ITA
+    - JPN
+    - KOR
+    - LTU
+    - LUX
+    - LVA
+    - MEX
+    - NLD
+    - NOR
+    - NZL
+    - POL
+    - PRT
+    - SVK
+    - SVN
+    - SWE
+    - TUR
+    - USA
+    - AUS
+
+  - Reforming Economies (R5):
+    - ALB
+    - ARM
+    - AZE
+    - BLR
+    - BIH
+    - GEO
+    - KAZ
+    - KGZ
+    - MKD
+    - MDA
+    - MNG
+    - RUS
+    - SRB
+    - TJK
+    - TKM
+    - UKR
+    - UZB
+
+  - Asia (R5):
+    - AFG
+    - BGD
+    - CHN
+    - HKG
+    - IDN
+    - IND
+    - KHM
+    - LAO
+    - MMR
+    - MYS
+    - NPL
+    - PAK
+    - PHL
+    - SGP
+    - THA
+    - VNM
+
+  - Middle East & Africa (R5):
+    - AGO
+    - BDI
+    - BEN
+    - BFA
+    - BHR
+    - BWA
+    - CAF
+    - CIV
+    - CMR
+    - COG
+    - CPV
+    - DJI
+    - DZA
+    - EGY
+    - ERI
+    - ETH
+    - GAB
+    - GHA
+    - GIN
+    - GMB
+    - GNB
+    - GNQ
+    - IRN
+    - IRQ
+    - JOR
+    - KEN
+    - KWT
+    - LBN
+    - LBR
+    - LBY
+    - LSO
+    - MAR
+    - MDG
+    - MLI
+    - MOZ
+    - MRT
+    - MUS
+    - MWI
+    - NAM
+    - NER
+    - NGA
+    - OMN
+    - QAT
+    - RWA
+    - SAU
+    - SDN
+    - SEN
+    - SLE
+    - SOM
+    - SSD
+    - STP
+    - SWZ
+    - SYC
+    - TCD
+    - TGO
+    - TUN
+    - TZA
+    - UGA
+    - YEM
+    - ZAF
+    - ZMB
+    - ZWE
+
+  - Latin America (R5):
+    - ARG
+    - BHS
+    - BLZ
+    - BOL
+    - BRA
+    - BRB
+    - CHL
+    - COL
+    - CUB
+    - DOM
+    - ECU
+    - GTM
+    - GUY
+    - HND
+    - HTI
+    - JAM
+    - NIC
+    - PAN
+    - PER
+    - PRY
+    - SLV
+    - SUR
+    - TTO
+    - URY
+    - VEN
+    - MEX
+
+# R9 regions
+  - European Union (R9):
+    - AUT
+    - BEL
+    - BGR
+    - HRV
+    - CYP
+    - CZE
+    - DNK
+    - EST
+    - FIN
+    - FRA
+    - DEU
+    - GRC
+    - HUN
+    - IRL
+    - ITA
+    - LVA
+    - LTU
+    - LUX
+    - MLT
+    - NLD
+    - POL
+    - PRT
+    - ROM
+    - SVK
+    - SVN
+    - ESP
+    - SWE
+  - USA (R9):
+    - USA
+
+  - Other OECD (R9):
+    - CAN
+    - AUS
+    - NZL
+    - JPN
+    - KOR
+    - NOR
+    - ISL
+    - CHE
+    - GBR
+    - TUR
+    - MEX
+
+  - China (R9):
+    - CHN
+
+  - India (R9):
+      - IND
+
+  - Other Asia (R9):
+    - IDN
+    - THA
+    - VNM
+    - MYS
+    - PHL
+    - SGP
+    - KHM
+    - LAO
+    - MMR
+    - BRN
+    - PRK
+
+  - Reforming Economies (R9):
+    - RUS
+    - UKR
+    - BLR
+    - KAZ
+    - KGZ
+    - TJK
+    - TKM
+    - UZB
+    - MNG
+
+  - Latin America (R9):
+    - ARG
+    - BOL
+    - BRA
+    - CHL
+    - COL
+    - ECU
+    - PER
+    - PRY
+    - URY
+    - VEN
+    - MEX
+    - GTM
+    - SLV
+    - HND
+    - NIC
+    - CRI
+    - PAN
+    - CUB
+    - DOM
+    - HTI
+    - JAM
+    - TTO
+    - BRB
+    - BHS
+    - GUY
+    - SRB
+    - SUR
+
+  - Middle East & Africa (R9):
+    - AFG
+    - BGD
+    - BHR
+    - IRN
+    - IRQ
+    - ISR
+    - JOR
+    - KWT
+    - LBN
+    - OMN
+    - QAT
+    - SAU
+    - ARE
+    - YEM
+    - DZA
+    - EGY
+    - MAR
+    - TUN
+    - LBY
+    - ESH
+    - NGA
+    - ZAF
+    - ETH
+    - KEN
+    - UGA
+    - TZA
+    - SOM
+    - SDN
+    - SSD
+    - AGO
+    - ZMB
+    - ZWE
+    - MOZ
+    - MWI
+    - NAM
+    - BWA
+    - LSO
+    - SWZ
+
+# R10 regions
+  - Africa (R10):
+    - DZA
+    - AGO
+    - BEN
+    - BFA
+    - BWA
+    - BDI
+    - CMR
+    - CAF
+    - TCD
+    - CIV
+    - COG
+    - COM
+    - CPV
+    - DJI
+    - EGY
+    - ERI
+    - ETH
+    - GAB
+    - GHA
+    - GIN
+    - GMB
+    - GNB
+    - GNQ
+    - KEN
+    - LBR
+    - LBY
+    - LSO
+    - MDG
+    - MLI
+    - MAR
+    - MRT
+    - MUS
+    - MWI
+    - MOZ
+    - NAM
+    - NER
+    - NGA
+    - RWA
+    - SEN
+    - SLE
+    - SOM
+    - SSD
+    - SDN
+    - SWZ
+    - SYC
+    - TCD
+    - TGO
+    - TUN
+    - TZA
+    - UGA
+    - ZAF
+    - ZMB
+    - ZWE
+
+  - China+ (R10):
+    - CHN
+    - KOR
+
+  - Europe (R10):
+    - AUT
+    - BEL
+    - BGR
+    - HRV
+    - CYP
+    - CZE
+    - DNK
+    - EST
+    - FIN
+    - FRA
+    - DEU
+    - GRC
+    - HUN
+    - IRL
+    - ITA
+    - LVA
+    - LTU
+    - LUX
+    - MLT
+    - NLD
+    - POL
+    - PRT
+    - ROM
+    - SVK
+    - SVN
+    - ESP
+    - SWE
+    - GBR
+    - CHE
+    - NOR
+    - ISL
+    - TUR
+
+  - India+ (R10):
+    - IND
+    - BGD
+    - PAK
+    - LKA
+    - NPL
+    - BTN
+    - AFG
+
+  - Latin America (R10):
+    - ARG
+    - BOL
+    - BRA
+    - CHL
+    - COL
+    - ECU
+    - PER
+    - PRY
+    - URY
+    - VEN
+    - MEX
+    - GTM
+    - SLV
+    - HND
+    - NIC
+    - CRI
+    - PAN
+    - CUB
+    - DOM
+    - HTI
+    - JAM
+    - TTO
+    - BRB
+    - BHS
+    - GUY
+    - SUR
+
+  - Middle East (R10):
+    - BHR
+    - IRN
+    - IRQ
+    - ISR
+    - JOR
+    - KWT
+    - LBN
+    - OMN
+    - QAT
+    - SAU
+    - ARE
+    - YEM
+
+  - North America (R10):
+    - USA
+    - CAN
+
+  - Pacific OECD (R10):
+    - AUS
+    - JPN
+    - NZL
+
+  - Reforming Economies (R10):
+    - RUS
+    - UKR
+    - BLR
+    - KAZ
+    - KGZ
+    - SRB
+    - TJK
+    - TKM
+    - UZB
+    - MNG
+
+  - Rest of Asia (R10):
+    - IDN
+    - THA
+    - VNM
+    - MYS
+    - PHL
+    - SGP
+    - KHM
+    - LAO
+    - MMR
+    - BRN
+    - PRK
+

--- a/mappings/IFs_v8.54.yaml
+++ b/mappings/IFs_v8.54.yaml
@@ -382,11 +382,14 @@ common_regions:
   - OECD & EU (R5):
     - AUT
     - BEL
+    - BGR
     - CAN
     - CHE
     - CHL
     - COL
     - CRI
+    - CYP
+    - CZE
     - DEU
     - DNK
     - ESP
@@ -395,6 +398,7 @@ common_regions:
     - FRA
     - GBR
     - GRC
+    - HRV
     - HUN
     - IRL
     - ISL
@@ -406,11 +410,13 @@ common_regions:
     - LUX
     - LVA
     - MEX
+    - MLT
     - NLD
     - NOR
     - NZL
     - POL
     - PRT
+    - ROU
     - SVK
     - SVN
     - SWE
@@ -427,6 +433,7 @@ common_regions:
     - GEO
     - KAZ
     - KGZ
+    - KOS
     - MKD
     - MDA
     - MNG
@@ -440,23 +447,38 @@ common_regions:
   - Asia (R5):
     - AFG
     - BGD
+    - BRN
+    - BTN
     - CHN
+    - FJI
+    - FSM
     - HKG
     - IDN
     - IND
+    - KIR
     - KHM
     - LAO
+    - LKA
+    - MDV
     - MMR
     - MYS
     - NPL
     - PAK
+    - PNG
     - PHL
+    - PRK
     - SGP
+    - SLB
     - THA
+    - TON
+    - TWN
     - VNM
+    - VUT
+    - WSM
 
   - Middle East & Africa (R5):
     - AGO
+    - ARE
     - BDI
     - BEN
     - BFA
@@ -466,11 +488,13 @@ common_regions:
     - CIV
     - CMR
     - COG
+    - COM
     - CPV
     - DJI
     - DZA
     - EGY
     - ERI
+    - ESH
     - ETH
     - GAB
     - GHA
@@ -498,6 +522,7 @@ common_regions:
     - NER
     - NGA
     - OMN
+    - PSE
     - QAT
     - RWA
     - SAU
@@ -509,6 +534,7 @@ common_regions:
     - STP
     - SWZ
     - SYC
+    - SYR
     - TCD
     - TGO
     - TUN
@@ -532,18 +558,23 @@ common_regions:
     - DOM
     - ECU
     - GTM
+    - GRD
     - GUY
     - HND
     - HTI
     - JAM
+    - LCA
     - NIC
     - PAN
     - PER
+    - PRI
     - PRY
     - SLV
     - SUR
+    - TLS
     - TTO
     - URY
+    - VCT
     - VEN
     - MEX
 
@@ -576,6 +607,7 @@ common_regions:
     - SVN
     - ESP
     - SWE
+  
   - USA (R9):
     - USA
 
@@ -594,127 +626,188 @@ common_regions:
 
   - China (R9):
     - CHN
+    - HKG
+    - TWN
 
   - India (R9):
-      - IND
+    - IND
 
   - Other Asia (R9):
+    - BTN
+    - BRN
+    - FJI
+    - FSM
     - IDN
-    - THA
-    - VNM
-    - MYS
-    - PHL
-    - SGP
+    - KIR
     - KHM
     - LAO
+    - LKA
+    - MDV
     - MMR
-    - BRN
+    - MYS
+    - NPL
+    - PAK
+    - PHL
+    - PNG
     - PRK
+    - SGP
+    - SLB
+    - THA
+    - TLS
+    - TON
+    - VNM
+    - VUT
+    - WSM
 
   - Reforming Economies (R9):
-    - RUS
-    - UKR
+    - ALB
+    - ARM
+    - AZE
+    - BIH
     - BLR
+    - GEO
     - KAZ
     - KGZ
+    - KOS
+    - MDA
+    - MKD
+    - MNG
+    - RUS
+    - SRB
     - TJK
     - TKM
+    - UKR
     - UZB
-    - MNG
-
+    
   - Latin America (R9):
     - ARG
+    - BLZ
     - BOL
     - BRA
+    - BRB
+    - BHS
     - CHL
     - COL
-    - ECU
-    - PER
-    - PRY
-    - URY
-    - VEN
-    - MEX
-    - GTM
-    - SLV
-    - HND
-    - NIC
-    - CRI
-    - PAN
     - CUB
     - DOM
     - HTI
     - JAM
-    - TTO
-    - BRB
-    - BHS
+    - CRI
+    - ECU
+    - GRD
+    - GTM
     - GUY
-    - SRB
+    - HND
+    - LCA
+    - MEX
+    - NIC
+    - PAN
+    - PER
+    - PRI
+    - PRY
+    - SLV
     - SUR
-
+    - TTO
+    - URY
+    - VCT
+    - VEN
+    
   - Middle East & Africa (R9):
     - AFG
+    - AGO
+    - ARE
+    - CAF
+    - BEN
+    - BDI
+    - BFA
     - BGD
     - BHR
-    - IRN
-    - IRQ
-    - ISR
-    - JOR
-    - KWT
-    - LBN
-    - OMN
-    - QAT
-    - SAU
-    - ARE
-    - YEM
-    - DZA
-    - EGY
-    - MAR
-    - TUN
-    - LBY
-    - ESH
-    - NGA
-    - ZAF
-    - ETH
-    - KEN
-    - UGA
-    - TZA
-    - SOM
-    - SDN
-    - SSD
-    - AGO
-    - ZMB
-    - ZWE
-    - MOZ
-    - MWI
-    - NAM
     - BWA
-    - LSO
-    - SWZ
-
-# R10 regions
-  - Africa (R10):
-    - DZA
-    - AGO
-    - BEN
-    - BFA
-    - BWA
-    - BDI
-    - CMR
-    - CAF
-    - TCD
     - CIV
+    - CMR
     - COG
     - COM
     - CPV
     - DJI
+    - DZA
     - EGY
     - ERI
+    - ESH
     - ETH
     - GAB
     - GHA
     - GIN
-    - GMB
     - GNB
+    - GMB
+    - GNQ
+    - IRN
+    - IRQ
+    - ISR
+    - JOR
+    - KEN
+    - KWT
+    - LBN
+    - LBR
+    - LBY
+    - LSO
+    - MAR
+    - MDG
+    - MLI
+    - MOZ
+    - MRT
+    - MUS
+    - MWI
+    - NAM
+    - NER
+    - NGA
+    - OMN
+    - PSE
+    - QAT
+    - RWA
+    - SAU
+    - SDN
+    - SEN
+    - SLE
+    - SOM
+    - SSD
+    - STP
+    - SWZ
+    - SYC
+    - SYR
+    - TCD
+    - TGO
+    - TUN
+    - TZA
+    - UGA
+    - YEM
+    - ZAF
+    - ZMB
+    - ZWE
+    
+# R10 regions
+  - Africa (R10):
+    - AGO
+    - BEN
+    - BDI
+    - BFA
+    - BWA
+    - CAF
+    - CIV
+    - CMR
+    - COG
+    - COM
+    - CPV
+    - DJI
+    - DZA
+    - EGY
+    - ERI
+    - ESH
+    - ETH
+    - GAB
+    - GHA
+    - GIN
+    - GNB
+    - GMB
     - GNQ
     - KEN
     - LBR
@@ -731,11 +824,12 @@ common_regions:
     - NER
     - NGA
     - RWA
+    - SDN
     - SEN
     - SLE
     - SOM
     - SSD
-    - SDN
+    - STP
     - SWZ
     - SYC
     - TCD
@@ -749,7 +843,9 @@ common_regions:
 
   - China+ (R10):
     - CHN
+    - HKG
     - KOR
+    - TWN
 
   - Europe (R10):
     - AUT
@@ -796,32 +892,37 @@ common_regions:
 
   - Latin America (R10):
     - ARG
+    - BHS
+    - BLZ
     - BOL
     - BRA
+    - BRB
     - CHL
     - COL
-    - ECU
-    - PER
-    - PRY
-    - URY
-    - VEN
-    - MEX
-    - GTM
-    - SLV
-    - HND
-    - NIC
     - CRI
-    - PAN
     - CUB
     - DOM
-    - HTI
-    - JAM
-    - TTO
-    - BRB
-    - BHS
+    - ECU
+    - GRD
+    - GTM
     - GUY
+    - HTI
+    - HND
+    - JAM
+    - LCA
+    - MEX
+    - NIC
+    - PAN
+    - PER
+    - PRI
+    - PRY
+    - SLV
     - SUR
-
+    - TTO
+    - URY
+    - VEN
+    - VCT
+    
   - Middle East (R10):
     - BHR
     - IRN
@@ -831,9 +932,11 @@ common_regions:
     - KWT
     - LBN
     - OMN
+    - PSE
     - QAT
     - SAU
     - ARE
+    - SYR
     - YEM
 
   - North America (R10):
@@ -846,27 +949,45 @@ common_regions:
     - NZL
 
   - Reforming Economies (R10):
-    - RUS
-    - UKR
+    - ALB
+    - ARM
+    - AZE
+    - BIH
     - BLR
+    - GEO
     - KAZ
     - KGZ
+    - KOS
+    - MDA
+    - MKD
+    - MNG
+    - RUS
     - SRB
     - TJK
     - TKM
+    - UKR
     - UZB
-    - MNG
-
+    
   - Rest of Asia (R10):
+    - BRN
+    - FJI
+    - FSM
     - IDN
-    - THA
-    - VNM
-    - MYS
-    - PHL
-    - SGP
+    - KIR
     - KHM
     - LAO
+    - MDV
     - MMR
-    - BRN
+    - MYS
+    - PHL
+    - PNG
     - PRK
-
+    - SGP
+    - SLB
+    - THA
+    - TLS
+    - TON
+    - VNM
+    - VUT
+    - WSM
+    

--- a/mappings/IFs_v8.54.yaml
+++ b/mappings/IFs_v8.54.yaml
@@ -282,7 +282,7 @@ common_regions:
     - KHM
     - KIR
     - KOR
-    - KSV
+    - KOS
     - KWT
     - LAO
     - LBN
@@ -328,8 +328,9 @@ common_regions:
     - PRK
     - PRT
     - PRY
+    - PSE
     - QAT
-    - ROM
+    - ROU
     - RUS
     - RWA
     - SAU
@@ -355,7 +356,7 @@ common_regions:
     - THA
     - TJK
     - TKM
-    - TMP
+    - TLS
     - TON
     - TTO
     - TUN
@@ -371,7 +372,6 @@ common_regions:
     - VEN
     - VNM
     - VUT
-    - WBG
     - WSM
     - YEM
     - ZAF
@@ -571,7 +571,7 @@ common_regions:
     - NLD
     - POL
     - PRT
-    - ROM
+    - ROU
     - SVK
     - SVN
     - ESP
@@ -774,7 +774,7 @@ common_regions:
     - NLD
     - POL
     - PRT
-    - ROM
+    - ROU
     - SVK
     - SVN
     - ESP

--- a/nomenclature.yaml
+++ b/nomenclature.yaml
@@ -18,7 +18,6 @@ definitions:
         - hierarchy: R9
         - hierarchy: R10
         - hierarchy: Regional Organizations
-        - hierarchy: G20 Members
         - hierarchy: IMAGE 3.4
         - hierarchy: MESSAGEix-GLOBIOM 2.1-R12
         - hierarchy: MESSAGEix-GLOBIOM-GAINS 2.1-R12
@@ -29,6 +28,7 @@ definitions:
         - hierarchy: WITCH 6.0-EU28
         - hierarchy: OPEN-PROM 2.2
         - hierarchy: IMACLIM 2.0
+    country: true
 
 mappings:
   repository:


### PR DESCRIPTION
This PR implements the mapping started by @VassilisDaioglou in https://github.com/IAMconsortium/common-definitions/pull/410, but it omits the model-name-prefix because the native regions are all countrIy names.

I double-checked the codes used by IFs v8.54 against the **nomenclature.countries** module ([read the docs](https://nomenclature-iamc.readthedocs.io/en/stable/api/countries.html)) and found the following inconsistencies:

- *IFs code -> alpha_3 code (country name)* 
- KSV -> KOS (Kosovo)
- ROM -> ROU (Romania)
- TMP -> TLS (Timor-Leste)
- WBG -> PSE (Palestine)

Any chance to harmonise the IFs v8.54 reporting to use the correct alpha-3 codes?

Also, there is a discrepancy: in the mapping, the code "COG" is mapped to "Democratic Republic of the Congo", but according to https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3, **COG** stands for Congo and **COD** stands for  "Democratic Republic of the Congo". Please double-check.

FYI @dc-almeida @lisahligono 