### PR TITLE
Update IFs_v8.54.yaml

### DIFF
--- a/mappings/IFs_v8.54.yaml
+++ b/mappings/IFs_v8.54.yaml
@@ -35,7 +35,7 @@ native_regions:
   - CHN: China
   - CIV: Côte d'Ivoire
   - CMR: Cameroon
-  - COG: Democratic Republic of the Congo
+  - COG: Congo
   - COL: Colombia
   - COM: Comoros
   - CPV: Cabo Verde
@@ -93,7 +93,7 @@ native_regions:
   - KHM: Cambodia
   - KIR: Kiribati
   - KOR: South Korea
-  - KSV: Kosovo
+  - KOS: Kosovo
   - KWT: Kuwait
   - LAO: Laos 
   - LBN: Lebanon
@@ -139,8 +139,9 @@ native_regions:
   - PRK: North Korea
   - PRT: Portugal
   - PRY: Paraguay
+  - PSE: Palestine
   - QAT: Qatar
-  - ROM: Romania
+  - ROU: Romania
   - RUS: Russian Federation
   - RWA: Rwanda
   - SAU: Saudi Arabia
@@ -166,7 +167,7 @@ native_regions:
   - THA: Thailand
   - TJK: Tajikistan
   - TKM: Turkmenistan
-  - TMP: Timor-Leste
+  - TLS: Timor-Leste
   - TON: Tonga
   - TTO: Trinidad and Tobago
   - TUN: Tunisia
@@ -182,7 +183,6 @@ native_regions:
   - VEN: Venezuela
   - VNM: Viet Nam
   - VUT: Vanuatu
-  - WBG: Palestine
   - WSM: Samoa
   - YEM: Yemen
   - ZAF: South Africa

--- a/mappings/IFs_v8.54.yaml
+++ b/mappings/IFs_v8.54.yaml
@@ -282,7 +282,7 @@ common_regions:
     - KHM
     - KIR
     - KOR
-    - KSV
+    - KOS
     - KWT
     - LAO
     - LBN
@@ -328,8 +328,9 @@ common_regions:
     - PRK
     - PRT
     - PRY
+    - PSE
     - QAT
-    - ROM
+    - ROU
     - RUS
     - RWA
     - SAU
@@ -355,7 +356,7 @@ common_regions:
     - THA
     - TJK
     - TKM
-    - TMP
+    - TLS
     - TON
     - TTO
     - TUN
@@ -371,7 +372,6 @@ common_regions:
     - VEN
     - VNM
     - VUT
-    - WBG
     - WSM
     - YEM
     - ZAF
@@ -571,7 +571,7 @@ common_regions:
     - NLD
     - POL
     - PRT
-    - ROM
+    - ROU
     - SVK
     - SVN
     - ESP
@@ -774,7 +774,7 @@ common_regions:
     - NLD
     - POL
     - PRT
-    - ROM
+    - ROU
     - SVK
     - SVN
     - ESP


### PR DESCRIPTION
Updated inconsistencies:

KSV -> KOS (Kosovo)
ROM -> ROU (Romania)
TMP -> TLS (Timor-Leste)
WBG -> PSE (Palestine)

Renamed "Democratic Republic of Congo" to "Congo" as required.